### PR TITLE
The single active consumer feature of RabbitMQ can now be activated u…

### DIFF
--- a/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/main/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQConnector.java
@@ -103,6 +103,7 @@ import io.vertx.rabbitmq.RabbitMQPublisherOptions;
 @ConnectorAttribute(name = "queue.auto-delete", direction = INCOMING, description = "Whether the queue should be deleted after use", type = "boolean", defaultValue = "false")
 @ConnectorAttribute(name = "queue.declare", direction = INCOMING, description = "Whether to declare the queue and binding; set to false if these are expected to be set up independently", type = "boolean", defaultValue = "true")
 @ConnectorAttribute(name = "queue.ttl", direction = INCOMING, description = "If specified, the time (ms) for which a message can remain in the queue undelivered before it is dead", type = "long")
+@ConnectorAttribute(name = "queue.single-active-consumer", direction = INCOMING, description = "If set to true, only one consumer can actively consume messages", type = "boolean")
 @ConnectorAttribute(name = "max-outgoing-internal-queue-size", direction = OUTGOING, description = "The maximum size of the outgoing internal queue", type = "int")
 @ConnectorAttribute(name = "max-incoming-internal-queue-size", direction = INCOMING, description = "The maximum size of the incoming internal queue", type = "int", defaultValue = "500000")
 
@@ -450,6 +451,7 @@ public class RabbitMQConnector implements IncomingConnectorFactory, OutgoingConn
         final JsonObject queueArgs = new JsonObject();
         queueArgs.put("x-dead-letter-exchange", ic.getDeadLetterExchange());
         queueArgs.put("x-dead-letter-routing-key", ic.getDeadLetterRoutingKey().orElse(queueName));
+        ic.getQueueSingleActiveConsumer().ifPresent(sac -> queueArgs.put("x-single-active-consumer", sac));
 
         ic.getQueueTtl().ifPresent(queueTtl -> {
             if (queueTtl >= 0) {

--- a/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
+++ b/smallrye-reactive-messaging-rabbitmq/src/test/java/io/smallrye/reactive/messaging/rabbitmq/RabbitMQTest.java
@@ -118,6 +118,7 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
                 .put("mp.messaging.incoming.data.queue.auto-delete", queueAutoDelete)
                 .put("mp.messaging.incoming.data.queue.declare", true)
                 .put("mp.messaging.incoming.data.queue.ttl", queueTtl)
+                .put("mp.messaging.incoming.data.queue.single-active-consumer", true)
                 .put("mp.messaging.incoming.data.routing-keys", routingKeys)
                 .put("mp.messaging.incoming.data.connector", RabbitMQConnector.CONNECTOR_NAME)
                 .put("mp.messaging.incoming.data.host", host)
@@ -154,6 +155,7 @@ class RabbitMQTest extends RabbitMQBrokerTestBase {
         assertThat(queueArguments.getString("x-dead-letter-exchange")).isEqualTo("DLX");
         assertThat(queueArguments.getString("x-dead-letter-routing-key")).isEqualTo(queueName);
         assertThat(queueArguments.getLong("x-message-ttl")).isEqualTo(queueTtl);
+        assertThat(queueArguments.getBoolean("x-single-active-consumer")).isEqualTo(true);
 
         final JsonArray queueBindings = usage.getBindings(exchangeName, queueName);
         assertThat(queueBindings.size()).isEqualTo(2);


### PR DESCRIPTION
…sing the `queue.single-active-consumer` property. See https://www.rabbitmq.com/consumers.html#single-active-consumer for more information